### PR TITLE
Add 64 bit support for hooking SDL XInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install
 ---------------------
 If you are on 64Bit you will need 32Bit tool-chain (multilib)
 
-Because this will generate 32Bit code, no 64Bit support !
+Because this will generate 32Bit code, for 64Bit support see below.
 
 It depens on SDL2-Librarys.
      
@@ -34,3 +34,13 @@ Config
 You can add sdl2 gamepad mappings by putting them in file named "gamecontrollerdb.txt" and place it next to your game executable, or via the *SDL_GAMECONTROLLERCONFIG* environment variable.
 
 You can find a premade gamecontrollerdb.txt with a lot of mappings [here](https://raw.githubusercontent.com/gabomdq/SDL_GameControllerDB/master/gamecontrollerdb.txt)
+
+Building for 64 bit
+---------------------
+You can build a 64 bit version by using the following cmake instead of the above:
+
+     [user&host code]$cmake -DBUILD_M32=OFF .
+
+Note: the CoSetProxyBlanket hook is not compiled into this build so might not work in some cases where the 32 bit version would.
+
+This is required for 64Bit games, if you're on 64Bit platform but running a 32Bit game you still need to compile as noted before.

--- a/device.cpp
+++ b/device.cpp
@@ -41,7 +41,6 @@ void DeviceInit(void* handle)
 		CoSetProxyBlanket_addr = addr;
 		memcpy(CoSetProxyBlanket_hook, (void*)CoSetProxyBlanket_addr, sizeof(Sjmp));
 
-                //func_override((void*)addr, (void*)CoSetProxyBlanket);
 		t_ptr addr_start = (addr - PAGESIZE-1) & ~(PAGESIZE-1);
 		t_ptr addr_end   = (addr + PAGESIZE-1) & ~(PAGESIZE-1);
 		mprotect((void*)addr_start, addr_end-addr_start , PROT_READ|PROT_WRITE|PROT_EXEC);

--- a/device.cpp
+++ b/device.cpp
@@ -15,12 +15,12 @@ const short wine_gamepad[] = {'V','I','D','_','3','E','D','9','&',
 							  'I','G','_','0','0'}; //you can get VID/PID from wine-source
 
 //what this does ? well.. hard to explain, please don't mind as long as it works
-long CoSetProxyBlanket_addr = 0;
+t_ptr CoSetProxyBlanket_addr = 0;
 char  CoSetProxyBlanket_hook[sizeof(Sjmp)];
-long CreateInstanceEnum_addr = 0;
-long CreateInstanceEnum_original;
-long Next_addr = 0;
-long Next_original;
+t_ptr CreateInstanceEnum_addr = 0;
+t_ptr CreateInstanceEnum_original;
+t_ptr Next_addr = 0;
+t_ptr Next_original;
 
 void DeviceInit(void* handle)
 {
@@ -29,7 +29,7 @@ void DeviceInit(void* handle)
 		clog << "koku-xinput-wine: search for `CoSetProxyBlanket`";
 	}
 	//hook functions
-	long addr = long(dlsym(handle, "CoSetProxyBlanket"));
+	t_ptr addr = t_ptr(dlsym(handle, "CoSetProxyBlanket"));
 
 	if (addr != 0)
 	{
@@ -41,8 +41,9 @@ void DeviceInit(void* handle)
 		CoSetProxyBlanket_addr = addr;
 		memcpy(CoSetProxyBlanket_hook, (void*)CoSetProxyBlanket_addr, sizeof(Sjmp));
 
-		long addr_start = (addr - PAGESIZE-1) & ~(PAGESIZE-1);
-		long addr_end   = (addr + PAGESIZE-1) & ~(PAGESIZE-1);
+                //func_override((void*)addr, (void*)CoSetProxyBlanket);
+		t_ptr addr_start = (addr - PAGESIZE-1) & ~(PAGESIZE-1);
+		t_ptr addr_end   = (addr + PAGESIZE-1) & ~(PAGESIZE-1);
 		mprotect((void*)addr_start, addr_end-addr_start , PROT_READ|PROT_WRITE|PROT_EXEC);
 
 		new ((void*)addr) Sjmp((void*)CoSetProxyBlanket);
@@ -67,16 +68,16 @@ void* WINAPI CoSetProxyBlanket(void* pProxy, unsigned dwAuthnSvc, unsigned dwAut
 	//enable hook
 	new ((void*)CoSetProxyBlanket_addr) Sjmp((void*)CoSetProxyBlanket);
 	//overwrite the function-table that CreateInstanceEnum goes to our function
-	long pProxy_func = *((long*)pProxy);
-	long pProxy_func_createinstanceenum = pProxy_func+0x48;
+	t_ptr pProxy_func = *((t_ptr*)pProxy);
+	t_ptr pProxy_func_createinstanceenum = pProxy_func+0x48;
 
-	long addr_start = (pProxy_func_createinstanceenum - PAGESIZE-1) & ~(PAGESIZE-1);
-	long addr_end   = (pProxy_func_createinstanceenum + PAGESIZE-1) & ~(PAGESIZE-1);
+	t_ptr addr_start = (pProxy_func_createinstanceenum - PAGESIZE-1) & ~(PAGESIZE-1);
+	t_ptr addr_end   = (pProxy_func_createinstanceenum + PAGESIZE-1) & ~(PAGESIZE-1);
 	mprotect((void*)addr_start, addr_end-addr_start , PROT_READ|PROT_WRITE|PROT_EXEC);
 
 	if (*((void**)(pProxy_func_createinstanceenum)) != (void*)CreateInstanceEnum)
 	{
-		CreateInstanceEnum_original = *((long*)(pProxy_func_createinstanceenum));
+		CreateInstanceEnum_original = *((t_ptr*)(pProxy_func_createinstanceenum));
 		CreateInstanceEnum_addr = pProxy_func_createinstanceenum;
 	}
 
@@ -109,17 +110,17 @@ void* WINAPI CreateInstanceEnum(void* pIWbemServices, short* bstrClassName, unsi
 	}
 
 	//overwrite the function-table that Next goes to our function
-	long pEnumDevices_func = **((long**)pEnumDevices);
-	long pEnumDevices_func_next = pEnumDevices_func+0x10;
+	t_ptr pEnumDevices_func = **((t_ptr**)pEnumDevices);
+	t_ptr pEnumDevices_func_next = pEnumDevices_func+0x10;
 
-	long addr_start = (pEnumDevices_func_next - PAGESIZE-1) & ~(PAGESIZE-1);
-	long addr_end   = (pEnumDevices_func_next + PAGESIZE-1) & ~(PAGESIZE-1);
+	t_ptr addr_start = (pEnumDevices_func_next - PAGESIZE-1) & ~(PAGESIZE-1);
+	t_ptr addr_end   = (pEnumDevices_func_next + PAGESIZE-1) & ~(PAGESIZE-1);
 	mprotect((void*)addr_start, addr_end-addr_start , PROT_READ|PROT_WRITE|PROT_EXEC);
 
 	if (*((void**)(pEnumDevices_func_next)) != (void*)EnumDevices_Next)
 	{
 		Next_addr     = pEnumDevices_func_next;
-		Next_original = *((long*)(pEnumDevices_func_next));
+		Next_original = *((t_ptr*)(pEnumDevices_func_next));
 	}
 
 	*((void**)(pEnumDevices_func_next)) = (void*)EnumDevices_Next;
@@ -151,13 +152,13 @@ void* WINAPI EnumDevices_Next(void* pEnumDevices, unsigned a, unsigned b, void**
 
 		//Very ugly stuff will happen now:
 		*pDevices = (void*)(new char[1024]);
-		*((void**)*pDevices) = (void*)(unsigned(*pDevices)+1);
+		*((void**)*pDevices) = (void*)(t_ptr(*pDevices)+1);
 
-		long pDevices_func = **((long**)pDevices);
-		long pDevices_func_get = pDevices_func+0x10;
+		t_ptr pDevices_func = **((t_ptr**)pDevices);
+		t_ptr pDevices_func_get = pDevices_func+0x10;
 
-		long addr_start = (pDevices_func_get - PAGESIZE-1) & ~(PAGESIZE-1);
-		long addr_end   = (pDevices_func_get + PAGESIZE-1) & ~(PAGESIZE-1);
+		t_ptr addr_start = (pDevices_func_get - PAGESIZE-1) & ~(PAGESIZE-1);
+		t_ptr addr_end   = (pDevices_func_get + PAGESIZE-1) & ~(PAGESIZE-1);
 		mprotect((void*)addr_start, addr_end-addr_start , PROT_READ|PROT_WRITE|PROT_EXEC);
 
 		*((void**)(pDevices_func_get)) = (void*)Devices_Get;

--- a/main.h
+++ b/main.h
@@ -2,22 +2,42 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <limits.h>
+#include <stdint.h>
 #ifndef PAGESIZE
 #define PAGESIZE 4096
 #endif
 
+typedef uintptr_t t_ptr;
+
+
 struct __attribute__((packed)) Sjmp
 {
-	unsigned char op;
-	void* value;
+        unsigned char op;
+#ifdef __LP64__
+        unsigned char op2;
+        void* value;
+        unsigned char op3;
+        unsigned char op4;
 
-	Sjmp(void* value):
-		op(0xE9), value((void*)((long)value-(long)&op-5))
-	{
-		/*
-		 This JITs a X86 jmp instruction
-		 */
-	}
+        Sjmp(void* value):
+                op(0x48), op2(0xb8), op3(0xff), op4(0xe0), value(value)
+        {
+                /*
+                 This JITs a AMD64 jmp instruction
+                 */
+        }
+#else
+        void* value;
+
+        Sjmp(void* value):
+                op(0xE9), value((void*)((t_ptr)value-(t_ptr)&op-5))
+        {
+                /*
+                 This JITs a X86 jmp instruction
+                 */
+        }
+#endif
+
 };
 
 extern bool debug;

--- a/xinput.h
+++ b/xinput.h
@@ -1,6 +1,20 @@
 #ifndef KOKU_XINPUT_H
 #define KOKU_XINPUT_H
-#define WINAPI  __attribute__((__stdcall__))
+//__stdcall declaration from wine/includes/windef.h
+#ifdef __LP64__
+#  if (__GNUC__ > 5) || ((__GNUC__ == 5) && (__GNUC_MINOR__ >= 3))
+#    define __stdcall __attribute__((ms_abi)) __attribute__((__force_align_arg_pointer__))
+#  else
+#    define __stdcall __attribute__((ms_abi))
+#  endif
+#else
+#  if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2)) || defined(__APPLE__)
+#    define __stdcall __attribute__((__stdcall__)) __attribute__((__force_align_arg_pointer__))
+#  else
+#    define __stdcall __attribute__((__stdcall__))
+#  endif
+#endif
+#define WINAPI  __stdcall
 #define ERROR_SUCCESS 			 0x0
 #define ERROR_DEVICE_NOT_CONNECTED 	 0x48f
 #define ERROR_EMPTY					0x10D2


### PR DESCRIPTION
This adds 64 bit support for the Sjmp mechanism.

Tested with some 64 bit games and it works.

Pointer arithmetic in device.cpp will need more work, but that's only for CoSetProxyBlanket mechanism that's not needed for all games. For this pull request I have disabled that part for 64 bit builds so as to not cause uneeded problems.

Also adds a WINAPI define backported from wine, to support 64bit. The new extended definition might need some testing.