### PR TITLE
As of Wine 3.1, XINPUT_STATE_EX no longer exists

### DIFF
--- a/xinput.cpp
+++ b/xinput.cpp
@@ -317,8 +317,8 @@ XInputGetBatteryInformation(DWORD dwUserIndex, BYTE devType,
 }
 
 koku::jumper<decltype(XInputGetStateEx)> XInputGetStateExJumper;
-DWORD WINAPI XInputGetStateEx(DWORD dwUserIndex, XINPUT_STATE_EX *pState) {
-  return koku::XInputGetState(dwUserIndex, (XINPUT_STATE *)pState);
+DWORD WINAPI XInputGetStateEx(DWORD dwUserIndex, XINPUT_STATE *pState) {
+  return koku::XInputGetState(dwUserIndex, pState);
 }
 
 void XInputInit(void *handle) {


### PR DESCRIPTION
This changes XInputGetStateEx to use XINPUT_STATE instead of
XINPUT_STATE_EX, which was removed from xinput.h in Wine 3.1.

See:
https://github.com/wine-mirror/wine/commit/de3591ca9803add117fbacb8abe9b335e2e44977#diff-2bd94ee2f73a16f93bda7805ff84f1e3
https://www.winehq.org/announce/3.1

This fixes issue #30 